### PR TITLE
Signup Page styles

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -19,3 +19,6 @@
 @import "styles/login/logintitle.scss";
 @import "styles/login/signUp.scss";
 @import "styles/login/submitButton.scss";
+
+@import "styles/signUp/signUpButton.scss";
+@import "styles/signUp/signupForm.scss";

--- a/src/pages/auth/Signup.js
+++ b/src/pages/auth/Signup.js
@@ -38,7 +38,8 @@ export default function Signup() {
   return (
     <Container>
       <Form as={Col} md={{ span: 6, offset: 3 }} className='mt-5'>
-        <h1 className='mt-5 mb-5'>Signup</h1>
+        <h1 className='signup-title'>Signup</h1>
+        <hr />
         <Form.Group controlId='formBasicName'>
           <Form.Label>Name</Form.Label>
           <Form.Control
@@ -81,9 +82,6 @@ export default function Signup() {
             type='number'
             placeholder='Enter phone number'
           />
-          <Form.Text className='text-muted'>
-            We'll never share your email with anyone else.
-          </Form.Text>
         </Form.Group>
         <Form.Check
           type='switch'
@@ -91,8 +89,17 @@ export default function Signup() {
           id='custom-switch'
           label='Share Location when logged in'
         />
-        <Form.Group className='mt-5'>
-          <Button variant='primary' type='submit' onClick={submitForm}>
+        <Form.Text className='text-muted'>
+          Your location will ONLY be used for app functionality and NEVER shared
+          with third-parties
+        </Form.Text>
+        <Form.Group className='submit-group'>
+          <Button
+            variant='primary'
+            type='submit'
+            onClick={submitForm}
+            className='signup-submit-button'
+          >
             Sign up
           </Button>
         </Form.Group>

--- a/src/styles/signUp/signUpButton.scss
+++ b/src/styles/signUp/signUpButton.scss
@@ -1,0 +1,18 @@
+button.signup-submit-button.btn.btn-primary {
+  margin: 2vh;
+  padding: 1vh;
+  width: 70%;
+  background: linear-gradient(to bottom, #bf7b41 5%, #cf9c77 100%);
+  background-color: #cf9c77;
+  box-shadow: 3px 3px 7px 0px #899599;
+  font-size: 1.3rem;
+}
+
+button.signup-submit-button.btn.btn-primary:hover {
+  background: linear-gradient(to bottom, #cf9c77 5%, #bf7b41 100%);
+  background-color: #bf7b41;
+}
+button.signup-submit-button.btn.btn-primary:active {
+  position: relative;
+  top: 0.2vh;
+}

--- a/src/styles/signUp/signupForm.scss
+++ b/src/styles/signUp/signupForm.scss
@@ -1,0 +1,8 @@
+h1.signup-title {
+  margin-top: 8vh;
+  margin-bottom: 2vh;
+}
+div.submit-group.form-group {
+  margin-top: 3vh;
+  margin-bottom: 8vh;
+}


### PR DESCRIPTION
## what this pullrequest does:
- It adjusts signUp page theme to match app global color palate theme.
- it adjusts Title margins and submit button margins to be symmetrical in space
- It adds muted-text to the share location checkbox 
![Screenshot from 2020-07-09 12-34-09](https://user-images.githubusercontent.com/62297579/87029475-84055b00-c1e0-11ea-9ef4-f0b66ba21d81.png)
- It adds a thin break-line between  the title and the form
![Screenshot from 2020-07-09 12-34-45](https://user-images.githubusercontent.com/62297579/87029565-9e3f3900-c1e0-11ea-923e-805548d28691.png)

Thoughts: I might want to add margin at the buttom so that the footer is not on the page when the page loads. However that would generate a lot of empty space that I don't think  I want.  I would love some styling advice on this.

Any and all constructive criticism to improve this page is more then welcome :smiley: 
